### PR TITLE
fix: change batch dimension to channel dimension

### DIFF
--- a/ulsam.py
+++ b/ulsam.py
@@ -117,13 +117,13 @@ class ULSAM(nn.Module):
         group_size = int(self.nin / self.num_splits)
 
         # split at batch dimension
-        sub_feat = torch.chunk(x, group_size, dim=0)
+        sub_feat = torch.chunk(x, self.num_splits, dim=1)
 
         out = []
         for idx, l in enumerate(self.subspaces):
             out.append(self.subspaces[idx](sub_feat[idx]))
 
-        out = torch.cat(out)
+        out = torch.cat(out, dim=1)
 
         return out
 


### PR DESCRIPTION
The PR proposes to change the batch dimension to channel dimension.
There is **no difference** in the results reported as the code was **rewritten** for the optimization. This bug is not present in the experiment environment. 